### PR TITLE
No longer assume that /noexist doesn't exist

### DIFF
--- a/VoLTE-HW/src/com/huawei/cust/HwCfgFilePolicy.java
+++ b/VoLTE-HW/src/com/huawei/cust/HwCfgFilePolicy.java
@@ -1,10 +1,9 @@
 package com.huawei.cust;
 
-import java.io.File;
-import android.util.Log;
+import java.io.FileNotFoundException;
 
 public class HwCfgFilePolicy {
 	public static File getCfgFile(String path, int a) {
-		return new File("/noexist");
+		throw new FileNotFoundException("STUBBY STUB STUB");
 	}
 }


### PR DESCRIPTION
This is ok, because a non-existent file will cause the same exception to be raised in the smali anyway...

NOTE: it's untested, i feel like i made a mistake in the java but i cant find one...