### PR TITLE
Fix VoLTE-CAF build-script to work with Xiaomi Mi Max 3

### DIFF
--- a/VoLTE-CAF/build.sh
+++ b/VoLTE-CAF/build.sh
@@ -38,13 +38,19 @@ cp "$system_folder"/lib64/libunwind.so "$libdst"
 cp "$system_folder"/lib64/libhardware.so "$libdst"
 cp "$system_folder"/lib64/libhwbinder.so "$libdst"
 cp "$system_folder"/lib64/liblzma.so "$libdst"
+cp "$system_folder"/lib64/libbufferhubqueue.so "$libdst"
+cp "$system_folder"/lib64/libpdx_default_transport.so "$libdst"
+cp "$system_folder"/lib64/libutilscallstack.so "$libdst"
+cp "$system_folder"/lib64/libcrypto.so "$libdst"
+cp "$system_folder"/lib64/libunwindstack.so "$libdst"
+cp "$system_folder"/lib64/libdexfile.so "$libdst"
 
-for i in android.hardware.media@1.0.so android.hardware.graphics.common@1.0.so android.hidl.token@1.0.so android.hardware.graphics.mapper@2.0.so android.hardware.graphics.allocator@2.0.so android.hidl.token@1.0-utils.so android.hardware.graphics.bufferqueue@1.0.so android.hardware.configstore@1.0.so android.hardware.configstore-utils.so;do
+for i in android.hardware.media@1.0.so android.hardware.graphics.common@1.0.so android.hardware.graphics.common@1.1.so android.hidl.token@1.0.so android.hardware.graphics.mapper@2.0.so android.hardware.graphics.mapper@2.1.so android.hardware.graphics.allocator@2.0.so android.hidl.token@1.0-utils.so android.hardware.graphics.bufferqueue@1.0.so android.hardware.configstore@1.0.so android.hardware.configstore@1.1.so android.hardware.configstore-utils.so;do
 	newName="$(echo "$i" |sed -E -e 's/^andr/libA/g' -e 's/@/-/g')"
 	cp "$system_folder"/lib64/$i "$libdst"/$newName
 done
 
-for i in android.hardware.media@1.0.so android.hardware.graphics.common@1.0.so android.hidl.token@1.0.so android.hardware.graphics.mapper@2.0.so android.hardware.graphics.allocator@2.0.so android.hidl.token@1.0-utils.so android.hardware.graphics.bufferqueue@1.0.so android.hardware.configstore@1.0.so android.hardware.configstore-utils.so;do
+for i in android.hardware.media@1.0.so android.hardware.graphics.common@1.0.so android.hardware.graphics.common@1.1.so android.hidl.token@1.0.so android.hardware.graphics.mapper@2.0.so android.hardware.graphics.mapper@2.1.so android.hardware.graphics.allocator@2.0.so android.hidl.token@1.0-utils.so android.hardware.graphics.bufferqueue@1.0.so android.hardware.configstore@1.0.so android.hardware.configstore@1.1.so android.hardware.configstore-utils.so;do
 	newName="$(echo "$i" |sed -E -e 's/^andr/libA/g' -e 's/@/-/g')"
 	sed -i -E "s/$i/$newName/g" "$libdst"/*.so
 done


### PR DESCRIPTION
I added a few missing library dependencies.
With this modified build-script we can produce a working ims.apk for Xiaomi Mi Max 3.

Adding the generated ims.apk to the system also fixes the "Can't receive SMS while on 4G / LTE" bug of this device.